### PR TITLE
use fully-qualified name for PathModify

### DIFF
--- a/quicklens/src/main/scala/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -26,7 +26,7 @@ object QuicklensMacros {
 
     val rootPathElParamTree = ValDef(Modifiers(), rootPathEl, TypeTree(), EmptyTree)
     val fnParamTree = ValDef(Modifiers(), fn, TypeTree(), EmptyTree)
-    q"new PathModify($obj, ($rootPathElParamTree, $fnParamTree) => $copies)"
+    q"new com.softwaremill.quicklens.PathModify($obj, ($rootPathElParamTree, $fnParamTree) => $copies)"
   }
 
   /**


### PR DESCRIPTION
Eliminate requirement for users to import PathModify.