### PR TITLE
cross-build quicklens for Scala.js

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,3 +1,5 @@
+import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport.crossProject
+import org.scalajs.sbtplugin.cross.CrossType
 import sbt.Keys._
 import sbt._
 
@@ -47,14 +49,17 @@ object QuicklensBuild extends Build {
     "root",
     file("."),
     settings = buildSettings ++ Seq(publishArtifact := false)
-  ) aggregate(quicklens, tests)
+  ) aggregate(quicklensJVM, quicklensJS, tests)
 
-  lazy val quicklens: Project = Project(
-    "quicklens",
-    file("quicklens"),
-    settings = buildSettings ++ Seq(
-      libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _))
-  )
+  lazy val quicklens = (crossProject.crossType(CrossType.Pure) in file("quicklens")).
+    settings(
+      buildSettings ++ Seq(
+        name := "quicklens",
+        libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _)): _*
+    )
+
+  lazy val quicklensJVM = quicklens.jvm
+  lazy val quicklensJS = quicklens.js
 
   lazy val tests: Project = Project(
     "tests",
@@ -66,5 +71,5 @@ object QuicklensBuild extends Build {
       // Otherwise when running tests in sbt, the macro is not visible
       // (both macro and usages are compiled in the same compiler run)
       fork in Test := true)
-  ) dependsOn(quicklens)
+  ) dependsOn(quicklensJVM)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.2")


### PR DESCRIPTION
I heard about quicklens a few weeks ago and have been wanting to try it out; the first time I've had a real reason is for Scala.js front-end work. I've locally published 1.3 built with this commit, and have used the javascript version and seems to work great (as all macro projects should).

Anyway, ScalaZ & Monocle have already been ported to SJS, and Shapeless is starting to release official builds, but those projects are scary to me (not smart enough yet) - it'd be cool if you published an official SJS artifact!