### PR TITLE
Add `modifyAll`, which allows to modify several fields in one go

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ person
   .modify(_.age).using(_ - 1)
 ````
 
+**Modify several fields in one go:**
+
+````scala
+import com.softwaremill.quicklens._
+
+case class Person(firstName: String, middleName: Option[String], lastName: String)
+
+val person = Person("john", Some("steve"), "smith")
+
+person.modifyAll(_.firstName, _.middleName.each, _.lastName).using(_.capitalize)
+````
+
 **Traverse options/lists using .each:**
 
 ````scala

--- a/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
@@ -17,6 +17,16 @@ package object quicklens {
    */
   def modify[T, U](obj: T)(path: T => U): PathModify[T, U] = macro QuicklensMacros.modify_impl[T, U]
 
+  /**
+   * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
+   * via `paths` on the given `obj`.
+   *
+   * All modifications are side-effect free and create copies of the original objects.
+   *
+   * You can use `.each` to traverse options, lists, etc.
+   */
+  def modifyAll[T, U](obj: T)(path1: T => U, paths: (T => U)*): PathModify[T, U] = macro QuicklensMacros.modifyAll_impl[T, U]
+
   implicit class ModifyPimp[T](t: T) {
     /**
      * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
@@ -27,17 +37,27 @@ package object quicklens {
      * You can use `.each` to traverse options, lists, etc.
      */
     def modify[U](path: T => U): PathModify[T, U] = macro QuicklensMacros.modifyPimp_impl[T, U]
+
+    /**
+     * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
+     * via `paths` on the given `obj`.
+     *
+     * All modifications are side-effect free and create copies of the original objects.
+     *
+     * You can use `.each` to traverse options, lists, etc.
+     */
+    def modifyAll[U](path1: T => U, paths: (T => U)*): PathModify[T, U] = macro QuicklensMacros.modifyAllPimp_impl[T, U]
   }
 
   case class PathModify[T, U](obj: T, doModify: (T, U => U) => T) {
     /**
-     * Transform the value of the field using the given function.
-     * @return A copy of the root object with the (deeply nested) field modified.
+     * Transform the value of the field(s) using the given function.
+     * @return A copy of the root object with the (deeply nested) field(s) modified.
      */
     def using(mod: U => U): T = doModify(obj, mod)
     /**
-     * Set the value of the field to a new value.
-     * @return A copy of the root object with the (deeply nested) field set to the new value.
+     * Set the value of the field(s) to a new value.
+     * @return A copy of the root object with the (deeply nested) field(s) set to the new value.
      */
     def setTo(v: U): T = doModify(obj, _ => v)
   }

--- a/tests/src/test/scala/com/softwaremill/quicklens/ModifyPimpTest.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/ModifyPimpTest.scala
@@ -12,4 +12,8 @@ class ModifyPimpTest extends FlatSpec with ShouldMatchers {
     a1.modify(_.a2.a3.a4.a5.name).using(duplicate)
       .modify(_.a2.a3.a4.a5.name).using(duplicate) should be (a1dupdup)
   }
+
+  it should "modify several fields" in {
+    b1.modifyAll(_.b2, _.b3.each).using(duplicate) should be (b1dupdup)
+  }
 }

--- a/tests/src/test/scala/com/softwaremill/quicklens/ModifySimpleTest.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/ModifySimpleTest.scala
@@ -11,4 +11,8 @@ class ModifySimpleTest extends FlatSpec with ShouldMatchers {
   it should "modify a deeply-nested case class field" in {
     modify(a1)(_.a2.a3.a4.a5.name).using(duplicate) should be (a1dup)
   }
+
+  it should "modify several fields" in {
+    modifyAll(b1)(_.b2, _.b3.each).using(duplicate) should be (b1dupdup)
+  }
 }

--- a/tests/src/test/scala/com/softwaremill/quicklens/TestData.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/TestData.scala
@@ -17,6 +17,11 @@ object TestData {
   val a1dupdup = A1(A2(A3(A4(A5("datadatadatadata")))))
   val a1mod = A1(A2(A3(A4(A5("mod")))))
 
+  case class B1(b2: String, b3: Option[String])
+
+  val b1 = B1("data", Some("data"))
+  val b1dupdup = B1("datadata", Some("datadata"))
+
   case class X1(x2: X2)
   case class X2(x3: Option[X3])
   case class X3(x4: X4)


### PR DESCRIPTION
Example:
````scala
import com.softwaremill.quicklens._

case class Person(firstName: String, middleName: Option[String], lastName: String)

val person = Person("john", Some("steve"), "smith")
val properPerson = Person("John", Some("Steve"), "Smith")

val modified = person.modifyAll(_.firstName, _.middleName.each, _.lastName)
  .using(_.capitalize)

modified shouldEqual properPerson
  
````