### PR TITLE
Enabled feature and deprecation warnings

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -35,6 +35,8 @@ object BuildSettings {
     licenses      := ("Apache2", new java.net.URL("http://www.apache.org/licenses/LICENSE-2.0.txt")) :: Nil,
     homepage      := Some(new java.net.URL("http://www.softwaremill.com"))
   )
+
+  val scalacSettings = Seq("-deprecation","-feature","-unchecked","-Ybackend:GenBCode")
 }
 
 object Dependencies {
@@ -55,6 +57,7 @@ object QuicklensBuild extends Build {
     settings(
       buildSettings ++ Seq(
         name := "quicklens",
+        scalacOptions ++= scalacSettings,
         libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _)): _*
     )
 
@@ -67,6 +70,7 @@ object QuicklensBuild extends Build {
     settings = buildSettings ++ Seq(
       publishArtifact := false,
       libraryDependencies ++= Seq(scalatest),
+      scalacOptions ++= scalacSettings,
       libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _ % "test"),
       // Otherwise when running tests in sbt, the macro is not visible
       // (both macro and usages are compiled in the same compiler run)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,7 +36,7 @@ object BuildSettings {
     homepage      := Some(new java.net.URL("http://www.softwaremill.com"))
   )
 
-  val scalacSettings = Seq("-deprecation","-feature","-unchecked","-Ybackend:GenBCode")
+  val scalacSettings = Seq("-deprecation","-feature","-unchecked")
 }
 
 object Dependencies {

--- a/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
@@ -5,6 +5,7 @@ import scala.collection.TraversableLike
 import scala.collection.SeqLike
 import scala.collection.generic.CanBuildFrom
 import scala.language.experimental.macros
+import scala.language.higherKinds
 
 package object quicklens {
   /**


### PR DESCRIPTION
I have enabled some sensible scalac warnings ("-deprecation","-feature","-unchecked") and fixed the feature ones. I would like to fix the deprecation as well, but I do not undestand the code enough yet.

The warning still left is:

[warn] .....\QuicklensMacros.scala:65: method Block in trait Trees is deprecated:
Use q"{..$stats}" instead. Flatten directly nested blocks manually if needed