### PR TITLE
Provide a support for all Map subclasses, tests for immutable.SortedMap.

### DIFF
--- a/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
@@ -102,7 +102,7 @@ package object quicklens {
     def at(fa: F[T], idx: Int)(f: T => T): F[T]
   }
 
-  implicit class QuicklensMapAt[K, T](t: Map[K, T])(implicit f: QuicklensMapAtFunctor[Map, K, T]) {
+  implicit class QuicklensMapAt[M[KT, TT] <: Map[KT, TT], K, T](t: M[K, T])(implicit f: QuicklensMapAtFunctor[M, K, T]) {
     @compileTimeOnly("at can only be used inside modify")
     def at(idx: K): T = sys.error("")
 
@@ -115,12 +115,12 @@ package object quicklens {
     def each(fa: F[K, T])(f: T => T): F[K, T]
   }
 
-  implicit def mapQuicklensFunctor[K, T] = new QuicklensMapAtFunctor[Map, K, T] {
-    override def at(fa: Map[K, T], key: K)(f: T => T) = {
-      fa.updated(key, f(fa(key)))
+  implicit def mapQuicklensFunctor[M[KT, TT] <: Map[KT, TT], K, T] = new QuicklensMapAtFunctor[M, K, T] {
+    override def at(fa: M[K, T], key: K)(f: T => T) = {
+      fa.updated(key, f(fa(key))).asInstanceOf[M[K, T]]
     }
-    override def each(fa: Map[K, T])(f: (T) => T) = {
-      fa.mapValues(f)
+    override def each(fa: M[K, T])(f: (T) => T) = {
+      fa.mapValues(f).asInstanceOf[M[K, T]]
     }
   }
 

--- a/tests/src/test/scala/com/softwaremill/quicklens/ModifyMapAtTest.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/ModifyMapAtTest.scala
@@ -10,7 +10,7 @@ class ModifyMapAtTest extends FlatSpec with ShouldMatchers {
   }
 
   it should "modify a non-nested sorted map with case class item" in {
-    modify(ms1)(_.at("K1").a5.name).using(duplicate) should be(ms1dup)
+    modify(ms1)(_.at("K1").a5.name).using(duplicate) should be(m1dup)
   }
 
   it should "modify a nested map using at" in {

--- a/tests/src/test/scala/com/softwaremill/quicklens/ModifyMapAtTest.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/ModifyMapAtTest.scala
@@ -9,6 +9,10 @@ class ModifyMapAtTest extends FlatSpec with ShouldMatchers {
     modify(m1)(_.at("K1").a5.name).using(duplicate) should be(m1dup)
   }
 
+  it should "modify a non-nested sorted map with case class item" in {
+    modify(ms1)(_.at("K1").a5.name).using(duplicate) should be(ms1dup)
+  }
+
   it should "modify a nested map using at" in {
     modify(m2)(_.m3.at("K1").a5.name).using(duplicate) should be(m2dup)
   }

--- a/tests/src/test/scala/com/softwaremill/quicklens/TestData.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/TestData.scala
@@ -66,5 +66,6 @@ object TestData {
   val m1dupEach = Map("K1" -> A4(A5("d1d1")), "K2" -> A4(A5("d2d2")), "K3" -> A4(A5("d3d3")))
   val m2dup = M2(Map("K1" -> A4(A5("d1d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3"))))
   val ms1 = collection.immutable.SortedMap("K1" -> A4(A5("d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
-  val ms1dup = collection.immutable.SortedMap("K1" -> A4(A5("d1d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
+  val mh1 = collection.immutable.HashMap("K1" -> A4(A5("d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
+  val ml1 = collection.immutable.ListMap("K1" -> A4(A5("d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
 }

--- a/tests/src/test/scala/com/softwaremill/quicklens/TestData.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/TestData.scala
@@ -65,4 +65,6 @@ object TestData {
   val m1dup = Map("K1" -> A4(A5("d1d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
   val m1dupEach = Map("K1" -> A4(A5("d1d1")), "K2" -> A4(A5("d2d2")), "K3" -> A4(A5("d3d3")))
   val m2dup = M2(Map("K1" -> A4(A5("d1d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3"))))
+  val ms1 = collection.immutable.SortedMap("K1" -> A4(A5("d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
+  val ms1dup = collection.immutable.SortedMap("K1" -> A4(A5("d1d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
 }


### PR DESCRIPTION
Changed type class and functor signatures to handle derived `Map`s as well (esp. `SortedMap`).