### PR TITLE
Implemented Seq at without full rebuild

### DIFF
--- a/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
@@ -1,7 +1,5 @@
 package com.softwaremill
 
-import java.util.NoSuchElementException
-
 import scala.annotation.compileTimeOnly
 import scala.collection.TraversableLike
 import scala.collection.SeqLike
@@ -129,12 +127,7 @@ package object quicklens {
   implicit def seqQuicklensFunctor[F[_], T](implicit cbf: CanBuildFrom[F[T], T, F[T]], ev: F[T] => SeqLike[T, F[T]]) =
     new QuicklensAtFunctor[F, T] {
       override def at(fa: F[T], idx: Int)(f: T => T) = {
-        try {
-          val (prefix, tail) = fa.splitAt(idx)
-          prefix ++ (f(tail.head) +: tail.tail)
-        } catch {
-          case xe: NoSuchElementException => throw new IndexOutOfBoundsException(xe.getMessage)
-        }
+        fa.updated(idx, f(fa(idx)))
       }
     }
 }


### PR DESCRIPTION
Some traversables (Vector) have [effectively constant performance guarantees](http://docs.scala-lang.org/overviews/collections/performance-characteristics.html) for most operations, avoiding full rebuild helps performance for them.

Moreover, I find this version much simpler and more readable.