### PR TITLE
Add `when`, which allows to modify only a given subtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ person.modify(_.props.at("Age").value).setTo("45")
 Similarly to `.each`, `.at` modifies only the element with the given key. If there's no such element,
 an `NoSuchElementException` is thrown.
 
+**Modify fields when they are of a certain subtype:**
+
+```scala
+trait Animal
+case class Dog(age: Int) extends Animal
+case class Cat(ages: List[Int]) extends Animal
+
+case class Zoo(animals: List[Animal])
+
+val zoo = Zoo(List(Dog(4), Cat(List(3, 12, 13))))
+
+val olderZoo = zoo.modifyAll(
+  _.animals.each.when[Dog].age,
+  _.animals.each.when[Cat].ages.at(0)
+).using(_ + 1)
+```
+
 **Re-usable modifications (lenses):**
 
 ````scala

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,8 @@ object BuildSettings {
   val buildSettings = Defaults.coreDefaultSettings ++ Seq (
     organization  := "com.softwaremill.quicklens",
     version       := "1.4.6",
-    crossScalaVersions := Seq("2.11.6", "2.12.0-M3"),
+    scalaVersion  := "2.11.8",
+    crossScalaVersions := Seq("2.11.8", "2.12.0-M3"),
     // Sonatype OSS deployment
     publishTo <<= version { (v: String) =>
       val nexus = "https://oss.sonatype.org/"

--- a/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
@@ -132,4 +132,9 @@ package object quicklens {
         fa.updated(idx, f(fa(idx)))
       }
     }
+
+  implicit class QuicklensWhen[A](value: A) {
+    @compileTimeOnly("when can only be used inside modify")
+    def when[B <: A]: B = sys.error("")
+  }
 }

--- a/tests/src/test/scala/com/softwaremill/quicklens/ModifyWhenTest.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/ModifyWhenTest.scala
@@ -1,0 +1,42 @@
+package com.softwaremill.quicklens
+
+import org.scalatest.{FlatSpec, Matchers}
+
+object ModifyWhenTestData {
+  trait Animal
+  case class Dog(age: Int) extends Animal
+  case class Cat(ages: List[Int]) extends Animal
+  case class Zoo(animals: List[Animal])
+
+  val dog: Animal = Dog(4)
+  val olderDog: Animal = Dog(5)
+
+  val cat: Animal = Cat(List(3, 12, 13))
+  val olderCat: Animal = Cat(List(4, 12, 13))
+
+  val zoo = Zoo(List(dog, cat))
+  val olderZoo = Zoo(List(olderDog, olderCat))
+}
+
+class ModifyWhenTest extends FlatSpec with Matchers {
+  import ModifyWhenTestData._
+
+  it should "modify a field in a subtype" in {
+    dog.modify(_.when[Dog].age).using(_ + 1) shouldEqual olderDog
+  }
+
+  it should "ignore subtypes other than the selected one" in {
+    cat.modify(_.when[Dog].age).using(_ + 1) shouldEqual cat
+  }
+
+  it should "modify a Functor field in a subtype" in {
+    cat.modify(_.when[Cat].ages.at(0)).using(_ + 1) shouldEqual olderCat
+  }
+
+  it should "modify a field in a subtype through a Functor" in {
+    zoo.modifyAll(
+      _.animals.each.when[Dog].age,
+      _.animals.each.when[Cat].ages.at(0)
+    ).using(_ + 1) shouldEqual olderZoo
+  }
+}


### PR DESCRIPTION
Example:

```scala
trait Animal
case class Dog(age: Int) extends Animal
case class Cat(ages: List[Int]) extends Animal

case class Zoo(animals: List[Animal])

val zoo = Zoo(List(Dog(4), Cat(List(3, 12, 13))))

val olderZoo = zoo.modifyAll(
  _.animals.each.when[Dog].age,
  _.animals.each.when[Cat].ages.at(0)
).using(_ + 1)
```