### PR TITLE
Adding "Lazy" modify capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ val upperCaseStreetName = modify(_: Person)(_.address.street.name).using(_.toUpp
 
 val p5 = upperCaseStreetName(person)
 ````
+Alternate syntax:
+````scala
+import com.softwaremill.quicklens._
+
+val modifyStreetName = modify[Person](_.address.street.name)
+
+val p3 = modifyStreetName(person).using(_.toUpperCase)
+val p4 = modifyStreetName(anotherPerson).using(_.toLowerCase)
+
+//
+
+val upperCaseStreetName = modify[Person](_.address.street.name).using(_.toUpperCase)
+
+val p5 = upperCaseStreetName(person)
+````
 
 **Composing lenses:**
 
@@ -171,6 +186,16 @@ val modifyStreetName = modify(_: Address)(_.street.name)
 
 val p6 = (modifyAddress andThenModify modifyStreetName)(person).using(_.toUpperCase)
 ````
+or, with alternate syntax:
+````scala
+import com.softwaremill.quicklens._
+
+val modifyAddress = modify[Person](_.address)
+val modifyStreetName = modify[Address](_.street.name)
+
+val p6 = (modifyAddress andThenModify modifyStreetName)(person).using(_.toUpperCase)
+````
+
 
 **Modify nested sealed hierarchies:**
 

--- a/quicklens/src/main/scala/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -33,6 +33,32 @@ object QuicklensMacros {
   }
 
   /**
+    * modify[A](_.b.c) => a => new PathMod(a, (A, F) => A.copy(b = A.b.copy(c = F(A.b.c))))
+    */
+  def modifyLazy_impl[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(
+    path: c.Expr[T => U]
+  ): c.Tree = modifyLazyUnwrapped(c)(modificationForPath(c)(path))
+
+  /**
+    * modifyAll[A](_.b.c, _.d.e) => a => new PathMod(a, << chained modifications >>)
+    */
+  def modifyLazyAll_impl[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(
+    path1: c.Expr[T => U],
+    paths: c.Expr[T => U]*
+  ): c.Tree = modifyLazyUnwrapped(c)(modificationsForPaths(c)(path1, paths))
+
+  /**
+    * A helper method for modify_impl and modifyAll_impl.
+    */
+  private def modifyLazyUnwrapped[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(
+    modifications: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    q"_root_.com.softwaremill.quicklens.PathLazyModify($modifications)"
+  }
+
+
+  /**
    * a.modify(_.b.c) => new PathMod(a, (A, F) => A.copy(b = A.b.copy(c = F(A.b.c))))
    */
   def modifyPimp_impl[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(

--- a/tests/src/test/scala/com/softwaremill/quicklens/LensLazyTest.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/LensLazyTest.scala
@@ -1,0 +1,21 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.{FlatSpec, Matchers}
+
+class LensLazyTest extends FlatSpec with Matchers {
+  it should "create reusable lens of the given type" in {
+    val lens = modify[A1](_.a2.a3.a4.a5.name)
+
+    val lm = lens.using(duplicate)
+    lm(a1) should be(a1dup)
+  }
+
+  it should "compose lens" in {
+    val lens_a1_a3 = modify[A1](_.a2.a3)
+    val lens_a3_name = modify[A3](_.a4.a5.name)
+
+    val lm = (lens_a1_a3 andThenModify lens_a3_name).using(duplicate)
+    lm(a1) should be(a1dup)
+  }
+}

--- a/tests/src/test/scala/com/softwaremill/quicklens/ModifyLazyTest.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/ModifyLazyTest.scala
@@ -1,0 +1,31 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.{FlatSpec, Matchers}
+
+class ModifyLazyTest extends FlatSpec with Matchers {
+  it should "modify a single-nested case class field" in {
+    val ml = modify[A5](_.name).using(duplicate)
+    ml(a5) should be(a5dup)
+  }
+
+  it should "modify a deeply-nested case class field" in {
+    val ml = modify[A1](_.a2.a3.a4.a5.name).using(duplicate)
+    ml(a1) should be(a1dup)
+  }
+
+  it should "modify several fields" in {
+    val ml = modifyAll[B1](_.b2, _.b3.each).using(duplicate)
+    ml(b1) should be(b1dupdup)
+  }
+
+  it should "modify a case class field if the condition is true" in {
+    val ml = modify[A5](_.name).usingIf(true)(duplicate)
+    ml(a5) should be(a5dup)
+  }
+
+  it should "leave a case class unchanged if the condition is flase" in {
+    val ml = modify[A5](_.name).usingIf(false)(duplicate)
+    ml(a5) should be(a5)
+  }
+}


### PR DESCRIPTION
Hi,
I propose to enable an alternate syntax for lenses definition: 
```scala
modify[Person](_.address)
```
and 
```scala
modifyAll[Person](_.firstName, _.middleName.each, _.lastName)
```