### PR TITLE
Adding "Lazy" modify and modifyAll capability to lenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ val upperCaseStreetName = modify(_: Person)(_.address.street.name).using(_.toUpp
 
 val p5 = upperCaseStreetName(person)
 ````
+Alternate syntax:
+````scala
+import com.softwaremill.quicklens._
+
+val modifyStreetName = modify[Person](_.address.street.name)
+
+val p3 = modifyStreetName(person).using(_.toUpperCase)
+val p4 = modifyStreetName(anotherPerson).using(_.toLowerCase)
+
+//
+
+val upperCaseStreetName = modify[Person](_.address.street.name).using(_.toUpperCase)
+
+val p5 = upperCaseStreetName(person)
+````
 
 **Composing lenses:**
 
@@ -171,6 +186,16 @@ val modifyStreetName = modify(_: Address)(_.street.name)
 
 val p6 = (modifyAddress andThenModify modifyStreetName)(person).using(_.toUpperCase)
 ````
+or, with alternate syntax:
+````scala
+import com.softwaremill.quicklens._
+
+val modifyAddress = modify[Person](_.address)
+val modifyStreetName = modify[Address](_.street.name)
+
+val p6 = (modifyAddress andThenModify modifyStreetName)(person).using(_.toUpperCase)
+````
+
 
 **Modify nested sealed hierarchies:**
 

--- a/quicklens/src/main/scala/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -33,6 +33,32 @@ object QuicklensMacros {
   }
 
   /**
+    * modify[A](_.b.c) => a => new PathMod(a, (A, F) => A.copy(b = A.b.copy(c = F(A.b.c))))
+    */
+  def modifyLazy_impl[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(
+    path: c.Expr[T => U]
+  ): c.Tree = modifyLazyUnwrapped(c)(modificationForPath(c)(path))
+
+  /**
+    * modifyAll[A](_.b.c, _.d.e) => a => new PathMod(a, << chained modifications >>)
+    */
+  def modifyLazyAll_impl[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(
+    path1: c.Expr[T => U],
+    paths: c.Expr[T => U]*
+  ): c.Tree = modifyLazyUnwrapped(c)(modificationsForPaths(c)(path1, paths))
+
+  /**
+    * A helper method for modify_impl and modifyAll_impl.
+    */
+  private def modifyLazyUnwrapped[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(
+    modifications: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    q"_root_.com.softwaremill.quicklens.PathLazyModify($modifications)"
+  }
+
+
+  /**
    * a.modify(_.b.c) => new PathMod(a, (A, F) => A.copy(b = A.b.copy(c = F(A.b.c))))
    */
   def modifyPimp_impl[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(

--- a/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala/com/softwaremill/quicklens/package.scala
@@ -1,8 +1,7 @@
 package com.softwaremill
 
 import scala.annotation.compileTimeOnly
-import scala.collection.TraversableLike
-import scala.collection.SeqLike
+import scala.collection.{SeqLike, TraversableLike}
 import scala.collection.generic.CanBuildFrom
 import scala.language.experimental.macros
 import scala.language.higherKinds
@@ -13,77 +12,89 @@ package object quicklens {
     s"$method can only be used inside modify"
 
   /**
-   * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
-   * via `path` on the given `obj`.
-   *
-   * All modifications are side-effect free and create copies of the original objects.
-   *
-   * You can use `.each` to traverse options, lists, etc.
-   */
+    * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
+    * via `path` on the given `obj`.
+    *
+    * All modifications are side-effect free and create copies of the original objects.
+    *
+    * You can use `.each` to traverse options, lists, etc.
+    */
   def modify[T, U](obj: T)(path: T => U): PathModify[T, U] = macro QuicklensMacros.modify_impl[T, U]
 
   /**
-   * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
-   * via `paths` on the given `obj`.
-   *
-   * All modifications are side-effect free and create copies of the original objects.
-   *
-   * You can use `.each` to traverse options, lists, etc.
-   */
-  def modifyAll[T, U](obj: T)(path1: T => U, paths: (T => U)*): PathModify[T, U] = macro QuicklensMacros.modifyAll_impl[T, U]
+    * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
+    * via `paths` on the given `obj`.
+    *
+    * All modifications are side-effect free and create copies of the original objects.
+    *
+    * You can use `.each` to traverse options, lists, etc.
+    */
+  def modifyAll[T, U](obj: T)
+                     (path1: T => U, paths: (T => U)*): PathModify[T, U] = macro QuicklensMacros.modifyAll_impl[T, U]
 
   implicit class ModifyPimp[T](t: T) {
     /**
-     * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
-     * via `path` on the given `obj`.
-     *
-     * All modifications are side-effect free and create copies of the original objects.
-     *
-     * You can use `.each` to traverse options, lists, etc.
-     */
+      * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
+      * via `path` on the given `obj`.
+      *
+      * All modifications are side-effect free and create copies of the original objects.
+      *
+      * You can use `.each` to traverse options, lists, etc.
+      */
     def modify[U](path: T => U): PathModify[T, U] = macro QuicklensMacros.modifyPimp_impl[T, U]
 
     /**
-     * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
-     * via `paths` on the given `obj`.
-     *
-     * All modifications are side-effect free and create copies of the original objects.
-     *
-     * You can use `.each` to traverse options, lists, etc.
-     */
+      * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
+      * via `paths` on the given `obj`.
+      *
+      * All modifications are side-effect free and create copies of the original objects.
+      *
+      * You can use `.each` to traverse options, lists, etc.
+      */
     def modifyAll[U](path1: T => U, paths: (T => U)*): PathModify[T, U] = macro QuicklensMacros.modifyAllPimp_impl[T, U]
   }
 
   case class PathModify[T, U](obj: T, doModify: (T, U => U) => T) {
     /**
-     * Transform the value of the field(s) using the given function.
-     * @return A copy of the root object with the (deeply nested) field(s) modified.
-     */
+      * Transform the value of the field(s) using the given function.
+      *
+      * @return A copy of the root object with the (deeply nested) field(s) modified.
+      */
     def using(mod: U => U): T = doModify(obj, mod)
+
     /**
       * Transform the value of the field(s) using the given function, if the condition is true. Otherwise, returns the
       * original object unchanged.
+      *
       * @return A copy of the root object with the (deeply nested) field(s) modified, if `condition` is true.
       */
-    def usingIf(condition: Boolean)(mod: U => U): T = if (condition) doModify(obj, mod) else obj
+    def usingIf(condition: Boolean)(mod: U => U): T = if (condition) doModify(obj, mod)
+    else obj
+
     /**
-     * Set the value of the field(s) to a new value.
-     * @return A copy of the root object with the (deeply nested) field(s) set to the new value.
-     */
+      * Set the value of the field(s) to a new value.
+      *
+      * @return A copy of the root object with the (deeply nested) field(s) set to the new value.
+      */
     def setTo(v: U): T = doModify(obj, _ => v)
+
     /**
       * Set the value of the field(s) to a new value, if it is defined. Otherwise, returns the original object
       * unchanged.
+      *
       * @return A copy of the root object with the (deeply nested) field(s) set to the new value, if it is defined.
       */
     def setToIfDefined(v: Option[U]): T = v.fold(obj)(setTo)
+
     /**
       * Set the value of the field(s) to a new value, if the condition is true. Otherwise, returns the original object
       * unchanged.
+      *
       * @return A copy of the root object with the (deeply nested) field(s) set to the new value, if `condition` is
       *         true.
       */
-    def setToIf(condition: Boolean)(v: => U): T = if (condition) setTo(v) else obj
+    def setToIf(condition: Boolean)(v: => U): T = if (condition) setTo(v)
+    else obj
   }
 
   implicit class AbstractPathModifyPimp[T, U](f1: T => PathModify[T, U]) {
@@ -91,6 +102,61 @@ package object quicklens {
       PathModify[T, V](t, (t, vv) => f1(t).doModify(t, u => f2(u).doModify(u, vv)))
     }
   }
+
+
+  def modify[T]: LensHelper[T] = LensHelper[T]()
+
+  def modifyAll[T]: MultiLensHelper[T] = MultiLensHelper[T]()
+
+  case class LensHelper[T] private() {
+
+    def apply[U](path: T => U): PathLazyModify[T, U] = macro QuicklensMacros.modifyLazy_impl[T, U]
+  }
+
+  case class MultiLensHelper[T] private() {
+
+    def apply[U](path1: T => U, paths: (T => U)*): PathLazyModify[T, U] = macro QuicklensMacros.modifyLazyAll_impl[T, U]
+  }
+
+
+  case class PathLazyModify[T, U](doModify: (T, U => U) => T) {
+
+    self =>
+
+    /**
+      * see [[PathModify.using]]
+      */
+    def using(mod: U => U): T => T = obj => doModify(obj, mod)
+
+    /**
+      * see [[PathModify.usingIf]]
+      */
+    def usingIf(condition: Boolean)(mod: U => U): T => T = obj => if (condition) doModify(obj, mod)
+    else obj
+
+    /**
+      * see [[PathModify.setTo]]
+      */
+    def setTo(v: U): T => T = obj => doModify(obj, _ => v)
+
+    /**
+      * see [[PathModify.setToIfDefined]]
+      */
+    def setToIfDefined(v: Option[U]): T => T = v.fold((obj: T) => obj)(setTo)
+
+    /**
+      * see [[PathModify.setToIf]]
+      */
+    def setToIf(condition: Boolean)(v: => U): T => T = if (condition) setTo(v)
+    else obj => obj
+
+    /**
+      * see [[AbstractPathModifyPimp]]
+      */
+    def andThenModify[V](f2: PathLazyModify[U, V]): PathLazyModify[T, V] =
+      PathLazyModify[T, V]((t, vv) => self.doModify(t, u => f2.doModify(u, vv)))
+  }
+
 
   implicit class QuicklensEach[F[_], T](t: F[T])(implicit f: QuicklensFunctor[F, T]) {
     @compileTimeOnly(canOnlyBeUsedInsideModify("each"))
@@ -102,8 +168,12 @@ package object quicklens {
 
   trait QuicklensFunctor[F[_], A] {
     def map(fa: F[A])(f: A => A): F[A]
+
     def each(fa: F[A])(f: A => A): F[A] = map(fa)(f)
-    def eachWhere(fa: F[A], p: A => Boolean)(f: A => A): F[A] = map(fa) { a => if (p(a)) f(a) else a }
+
+    def eachWhere(fa: F[A], p: A => Boolean)(f: A => A): F[A] = map(fa) { a => if (p(a)) f(a)
+    else a
+    }
   }
 
   implicit def optionQuicklensFunctor[A]: QuicklensFunctor[Option, A] =
@@ -111,7 +181,8 @@ package object quicklens {
       override def map(fa: Option[A])(f: A => A) = fa.map(f)
     }
 
-  implicit def traversableQuicklensFunctor[F[_], A](implicit cbf: CanBuildFrom[F[A], A, F[A]], ev: F[A] => TraversableLike[A, F[A]]) =
+  implicit def traversableQuicklensFunctor[F[_], A](implicit cbf: CanBuildFrom[F[A], A, F[A]],
+                                                    ev: F[A] => TraversableLike[A, F[A]]) =
     new QuicklensFunctor[F, A] {
       override def map(fa: F[A])(f: A => A) = fa.map(f)
     }
@@ -125,7 +196,8 @@ package object quicklens {
     def at(fa: F[T], idx: Int)(f: T => T): F[T]
   }
 
-  implicit class QuicklensMapAt[M[KT, TT] <: Map[KT, TT], K, T](t: M[K, T])(implicit f: QuicklensMapAtFunctor[M, K, T]) {
+  implicit class QuicklensMapAt[M[KT, TT] <: Map[KT, TT], K, T](t: M[K, T])
+                                                               (implicit f: QuicklensMapAtFunctor[M, K, T]) {
     @compileTimeOnly(canOnlyBeUsedInsideModify("at"))
     def at(idx: K): T = sys.error("")
 
@@ -135,6 +207,7 @@ package object quicklens {
 
   trait QuicklensMapAtFunctor[F[_, _], K, T] {
     def at(fa: F[K, T], idx: K)(f: T => T): F[K, T]
+
     def each(fa: F[K, T])(f: T => T): F[K, T]
   }
 
@@ -142,9 +215,10 @@ package object quicklens {
     override def at(fa: M[K, T], key: K)(f: T => T) = {
       fa.updated(key, f(fa(key))).asInstanceOf[M[K, T]]
     }
+
     override def each(fa: M[K, T])(f: (T) => T) = {
       val builder = cbf(fa)
-      fa.foreach { case(k, t) => builder += k -> f(t) }
+      fa.foreach { case (k, t) => builder += k -> f(t) }
       builder.result
     }
   }
@@ -162,7 +236,7 @@ package object quicklens {
   }
 
   implicit class QuicklensEither[T[_, _], L, R](e: T[L, R])
-                                      (implicit f: QuicklensEitherFunctor[T, L, R]) {
+                                               (implicit f: QuicklensEitherFunctor[T, L, R]) {
     @compileTimeOnly(canOnlyBeUsedInsideModify("eachLeft"))
     def eachLeft: L = sys.error("")
 
@@ -172,12 +246,14 @@ package object quicklens {
 
   trait QuicklensEitherFunctor[T[_, _], L, R] {
     def eachLeft(e: T[L, R])(f: L => L): T[L, R]
+
     def eachRight(e: T[L, R])(f: R => R): T[L, R]
   }
 
   implicit def eitherQuicklensFunctor[T[_, _], L, R]: QuicklensEitherFunctor[Either, L, R] =
     new QuicklensEitherFunctor[Either, L, R] {
       override def eachLeft(e: Either[L, R])(f: (L) => L) = e.left.map(f)
+
       override def eachRight(e: Either[L, R])(f: (R) => R) = e.right.map(f)
     }
 }

--- a/tests/src/test/scala/com/softwaremill/quicklens/LensLazyTest.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/LensLazyTest.scala
@@ -1,0 +1,21 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.{FlatSpec, Matchers}
+
+class LensLazyTest extends FlatSpec with Matchers {
+  it should "create reusable lens of the given type" in {
+    val lens = modify[A1](_.a2.a3.a4.a5.name)
+
+    val lm = lens.using(duplicate)
+    lm(a1) should be(a1dup)
+  }
+
+  it should "compose lens" in {
+    val lens_a1_a3 = modify[A1](_.a2.a3)
+    val lens_a3_name = modify[A3](_.a4.a5.name)
+
+    val lm = (lens_a1_a3 andThenModify lens_a3_name).using(duplicate)
+    lm(a1) should be(a1dup)
+  }
+}

--- a/tests/src/test/scala/com/softwaremill/quicklens/ModifyLazyTest.scala
+++ b/tests/src/test/scala/com/softwaremill/quicklens/ModifyLazyTest.scala
@@ -1,0 +1,31 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.{FlatSpec, Matchers}
+
+class ModifyLazyTest extends FlatSpec with Matchers {
+  it should "modify a single-nested case class field" in {
+    val ml = modify[A5](_.name).using(duplicate)
+    ml(a5) should be(a5dup)
+  }
+
+  it should "modify a deeply-nested case class field" in {
+    val ml = modify[A1](_.a2.a3.a4.a5.name).using(duplicate)
+    ml(a1) should be(a1dup)
+  }
+
+  it should "modify several fields" in {
+    val ml = modifyAll[B1](_.b2, _.b3.each).using(duplicate)
+    ml(b1) should be(b1dupdup)
+  }
+
+  it should "modify a case class field if the condition is true" in {
+    val ml = modify[A5](_.name).usingIf(true)(duplicate)
+    ml(a5) should be(a5dup)
+  }
+
+  it should "leave a case class unchanged if the condition is flase" in {
+    val ml = modify[A5](_.name).usingIf(false)(duplicate)
+    ml(a5) should be(a5)
+  }
+}


### PR DESCRIPTION
Hi,
I propose to enable an alternate syntax for lenses definition: 
```scala
modify[Person](_.address)
```
and 
```scala
modifyAll[Person](_.firstName, _.middleName.each, _.lastName)
```